### PR TITLE
Update CNAME to keeer.cf

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,2 @@
-www.keeer.ml
+www.keeer.cf
+keeer.cf


### PR DESCRIPTION
keeer.ml was occupied and charged for a fee to use.
So it is with keeer.tk and keeer.ga.
I hereby sincerely express my apologies and registered a new domain keeer.cf.